### PR TITLE
created EnemyWaveManger

### DIFF
--- a/Assets/_Scripts/Core/Board/BoardController.cs
+++ b/Assets/_Scripts/Core/Board/BoardController.cs
@@ -34,11 +34,13 @@ namespace Core.Board
             // uncomment next line for testing purposes to show where the enemy ships are placed
             //enemyView.revealShips = true;
 
+            EnemyWaveManager enemyWaveManager = new EnemyWaveManager();
+
             // create a list of enemy ships with given lengths
-            List<ShipModel> ships = EnemyWaveManager.Instance.createDefaultWaveOfShips();
+            List<ShipModel> ships = enemyWaveManager.CreateDefaultWaveOfShips();
 
             // randomly set the enemy ship locations and orientations, and place them on the enemyView board
-            EnemyWaveManager.Instance.randomlySetShipsLocations(enemyView, ships);
+            enemyWaveManager.RandomlySetShipsLocations(enemyView, ships);
 
         }
 

--- a/Assets/_Scripts/Core/Board/BoardController.cs
+++ b/Assets/_Scripts/Core/Board/BoardController.cs
@@ -1,6 +1,9 @@
+
 using Core.GridSystem;
 using Core.Ship;
+
 using UnityEngine;
+using System.Collections.Generic;
 
 namespace Core.Board
 {
@@ -26,19 +29,17 @@ namespace Core.Board
                 length = 4,
                 orientation = Orientation.Horizontal,
             });
-            
-            enemyView.TryPlaceShip(new ShipModel
-            {
-                root = new GridPos(1,1),
-                length = 3,
-                orientation = Orientation.Horizontal,
-            });
-            enemyView.TryPlaceShip(new ShipModel
-            {
-                root = new GridPos(6,4),
-                length = 2,
-                orientation = Orientation.Horizontal,
-            });
+
+
+            // uncomment next line for testing purposes to show where the enemy ships are placed
+            //enemyView.revealShips = true;
+
+            // create a list of enemy ships with given lengths
+            List<ShipModel> ships = EnemyWaveManager.Instance.createDefaultWaveOfShips();
+
+            // randomly set the enemy ship locations and orientations, and place them on the enemyView board
+            EnemyWaveManager.Instance.randomlySetShipsLocations(enemyView, ships);
+
         }
 
         void Update()
@@ -68,5 +69,6 @@ namespace Core.Board
                 return false;
             return view.WorldToGrid(hit.point, out cell);
         }
+
     }
 }

--- a/Assets/_Scripts/Core/Ship/EnemyWaveManager.cs
+++ b/Assets/_Scripts/Core/Ship/EnemyWaveManager.cs
@@ -1,0 +1,120 @@
+
+using Core.GridSystem;
+using Core.Board;
+
+using UnityEngine;
+using System.Collections.Generic;
+using System;
+using Random = System.Random;
+using UnityEngine.UIElements;
+using System.Drawing;
+using Unity.VisualScripting;
+
+
+namespace Core.Ship
+{
+    [System.Serializable]
+    public class EnemyWaveManager
+    {
+        public const int DEFAULT_NUM_SHIPS = 4;
+        public int[] DEFAULT_SHIP_LENGTHS = { 4, 3, 2, 1 };
+
+        public int waveNumber = 0;
+
+        private Random rnd = new Random();
+
+
+        // instantiate this as a singleton
+        private static readonly EnemyWaveManager instance = new EnemyWaveManager();
+
+        static EnemyWaveManager()
+        {
+        }
+
+        private EnemyWaveManager()
+        {
+        }
+
+        public static EnemyWaveManager Instance
+        {
+            get
+            {
+                return instance;
+            }
+        }
+
+        public List<ShipModel> createDefaultWaveOfShips()
+        {
+            List<ShipModel> ships = new List<ShipModel>();
+
+            for (int i=0; i < DEFAULT_NUM_SHIPS; i++)
+            {
+                ships.Add(new ShipModel
+                {
+                    length = DEFAULT_SHIP_LENGTHS[i]
+                });
+            }
+
+            return ships;
+        }
+
+
+        // Takes in a wave of ships, randomly sets their rotation, and randomly sets  
+        // 		the x & y coordinates to valid positions of the BoardView's grid 
+        //
+        // The algorithm used is to test all possible locations on the board that the ship can fit
+        //      and randomly select one
+        //
+        // Returns: true - all ships are in valid locations
+        //          false - at least one of the ships could not be placed in a valid location
+        //
+        public bool randomlySetShipsLocations(BoardView board, List<ShipModel> ships)
+        {
+            List<GridPos> validLocations = new List<GridPos>();     // valid GridPos cells that the ship can fit
+            bool haveBeenSuccessfullyPlaced = true;
+
+            foreach (ShipModel ship in ships)
+            {
+                validLocations.Clear();
+
+                ship.orientation = (Orientation)rnd.Next(2);
+
+                int lastCol = board.width;
+                int lastRow = board.height;
+                // if the ship is horizontal, we know a ship of size > 1 won't fit in the rightmost columns, so don't bother testing those
+                if (ship.orientation == Orientation.Horizontal)
+                    lastCol = lastCol - ship.length + 1;
+
+                // if the ship is vertical, we know a ship of size > 1 won't fit in the bottommost rows, so don't bother testing those
+                else   
+                    lastRow = lastRow - ship.length + 1;
+
+                // test every position on the board to see if it is a valid GridPos, and if so, add to validLocations
+                for (int col = 0; col < lastCol; col++) 
+                {
+                    for (int row = 0; row < lastRow; row++)
+                    {
+                        GridPos root = new GridPos(col, row);
+                        if (board.Model.ValidateShipPlacement(root, ship.length, ship.orientation))
+                        {
+                            validLocations.Add(root);
+                        }
+                    }
+                }
+
+                if (validLocations.Count == 0)
+                    haveBeenSuccessfullyPlaced = false;
+                else 
+                { 
+                    // randomly choose one of the validLocations to set as the ship's root 
+                    int index = rnd.Next(validLocations.Count);
+                    ship.root = validLocations[index];
+                    board.TryPlaceShip(ship);
+                }
+            }
+
+            return haveBeenSuccessfullyPlaced;
+        }
+
+    }
+}

--- a/Assets/_Scripts/Core/Ship/EnemyWaveManager.cs
+++ b/Assets/_Scripts/Core/Ship/EnemyWaveManager.cs
@@ -13,7 +13,7 @@ using Unity.VisualScripting;
 
 namespace Core.Ship
 {
-    [System.Serializable]
+
     public class EnemyWaveManager
     {
         public const int DEFAULT_NUM_SHIPS = 4;
@@ -24,26 +24,7 @@ namespace Core.Ship
         private Random rnd = new Random();
 
 
-        // instantiate this as a singleton
-        private static readonly EnemyWaveManager instance = new EnemyWaveManager();
-
-        static EnemyWaveManager()
-        {
-        }
-
-        private EnemyWaveManager()
-        {
-        }
-
-        public static EnemyWaveManager Instance
-        {
-            get
-            {
-                return instance;
-            }
-        }
-
-        public List<ShipModel> createDefaultWaveOfShips()
+        public List<ShipModel> CreateDefaultWaveOfShips()
         {
             List<ShipModel> ships = new List<ShipModel>();
 
@@ -68,7 +49,7 @@ namespace Core.Ship
         // Returns: true - all ships are in valid locations
         //          false - at least one of the ships could not be placed in a valid location
         //
-        public bool randomlySetShipsLocations(BoardView board, List<ShipModel> ships)
+        public bool RandomlySetShipsLocations(BoardView board, List<ShipModel> ships)
         {
             List<GridPos> validLocations = new List<GridPos>();     // valid GridPos cells that the ship can fit
             bool haveBeenSuccessfullyPlaced = true;

--- a/Assets/_Scripts/Core/Ship/EnemyWaveManager.cs.meta
+++ b/Assets/_Scripts/Core/Ship/EnemyWaveManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2130b25fe44b99e4387d221d14104d30


### PR DESCRIPTION
EnemyWaveManger can create a wave of enemy ships and set them in valid locations on the enemy board.

BoardController calls EnemyWaveManger to set a default wave of enemy ships on the enemy board.
In BoardController uncomment this line (35) to see all the enemy boats:
enemyView.revealShips = true;