### PR TITLE
SYS_002 - Ship Movement restriction

### DIFF
--- a/Assets/_Scenes/Game.unity
+++ b/Assets/_Scenes/Game.unity
@@ -119,6 +119,17 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!114 &13049830 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8610130497200863037, guid: b966cab18bc37be458f3a3c9a287cfc9, type: 3}
+  m_PrefabInstance: {fileID: 785932791298956241}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &21198329
 GameObject:
   m_ObjectHideFlags: 0
@@ -10583,6 +10594,17 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1711792940}
   m_CullTransparentMesh: 1
+--- !u!114 &1738965340 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1411188738233424621, guid: b966cab18bc37be458f3a3c9a287cfc9, type: 3}
+  m_PrefabInstance: {fileID: 785932791298956241}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1775954020
 GameObject:
   m_ObjectHideFlags: 0
@@ -13228,6 +13250,14 @@ PrefabInstance:
       propertyPath: boardController
       value: 
       objectReference: {fileID: 64301709}
+    - target: {fileID: 8669010056232355852, guid: 8f3f618652e66b847a645fe197ce3a12, type: 3}
+      propertyPath: rotateLeftButton
+      value: 
+      objectReference: {fileID: 1738965340}
+    - target: {fileID: 8669010056232355852, guid: 8f3f618652e66b847a645fe197ce3a12, type: 3}
+      propertyPath: rotateRightButton
+      value: 
+      objectReference: {fileID: 13049830}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []

--- a/Assets/_Scripts/Core/Board/BoardController.cs
+++ b/Assets/_Scripts/Core/Board/BoardController.cs
@@ -116,6 +116,10 @@ namespace Core.Board
             
             OnShipSelected?.Invoke(true);
 
+
+            // enable/disable the rotate buttons
+            GameManager.instance.rotateLeftButton.interactable = shipView.shipModel.canRotate;
+            GameManager.instance.rotateRightButton.interactable = shipView.shipModel.canRotate;
         }
 
         public void ClearSelectedShip()
@@ -154,6 +158,8 @@ namespace Core.Board
         public void UpdateEnemyShips()
         {
             Debug.Log("UpdateEnemyShips");
+
+            enemyView.BeginMovementPhase();
 
             // randomly set the enemy ship locations and orientations, and place them on the enemyView board
             _enemyWaveManager.RandomlyMoveShips(enemyView);

--- a/Assets/_Scripts/Core/Board/BoardView.cs
+++ b/Assets/_Scripts/Core/Board/BoardView.cs
@@ -42,6 +42,15 @@ namespace Core.Board
             if (cellPrefab) BuildGrid();
         }
 
+        public void BeginMovementPhase()
+        {
+            // reset the ship's movementPatterns so they can move again
+            foreach (var pair in SpawnedShips)
+            {
+                pair.Value.shipModel.movementPattern.Reset();
+            }
+        }
+
         public void Reset()
         {
             //HideShips();
@@ -74,6 +83,7 @@ namespace Core.Board
             {
                 wasSuccessful &= previousShipPlacements.TryGetValue(pair.Key, out previousShipData);
                 pair.Value.UpdatePosition(previousShipData.root, previousShipData.orientation);
+                pair.Value.shipModel.movementPattern.Reset();
             }
 
             return wasSuccessful;

--- a/Assets/_Scripts/Core/Ship/ShipModel.cs
+++ b/Assets/_Scripts/Core/Ship/ShipModel.cs
@@ -20,7 +20,7 @@ namespace Core.Ship
     {
         public string id;
         public ShipType type;
-        public int length = 3;
+        public int length;
         public bool submerged = false;
         public int hp;
         public int MaxHP => length;
@@ -30,6 +30,11 @@ namespace Core.Ship
         public GridPos reserved = new GridPos(-1000, -1000); // bow (front) position   
         public bool isDestroyed = false;
         private int _round = 0;
+        public ShipMovementPattern movementPattern = null;
+        public bool canMove => !isDestroyed && movementPattern != null && movementPattern.canMove;
+        public bool canRotate => !isDestroyed && movementPattern != null && movementPattern.canRotate;
+
+
         /// <summary>Apply damage and return true if the ship just sunk.</summary>
         public bool ApplyDamage(int damage = 1)
         {
@@ -202,6 +207,7 @@ namespace Core.Ship
                 hp = hp,
                 isDestroyed = isDestroyed,
                 _round = _round,
+                movementPattern = ShipMovementPattern.CreateMovementPattern(type)
             };
             return copy;
         }
@@ -222,6 +228,9 @@ namespace Core.Ship
 
         public GridPos MoveTo(GridPos point)
         {
+            if (GameManager.instance.phaseState != GameManager.PHASE_STATE.PLAYER_PLACING_SHIPS)
+                movementPattern.hasAlreadyMoved = true;
+
             return point;
         }
 
@@ -257,8 +266,7 @@ namespace Core.Ship
 
         public List<GridPos> GetMovablePositions(BoardView playerView)
         {
-            ShipMovementPattern pattern = ShipMovementPattern.CreateMovementPattern(type);
-            return pattern.GetAllPossibleMovePositions(playerView, this);
+            return movementPattern.GetAllPossibleMovePositions(playerView, this);
         }
     }
 
@@ -266,10 +274,10 @@ namespace Core.Ship
     {
         public static readonly Dictionary<ShipType, ShipModel> DefaultShips = new()
         {
-            { ShipType.Battleship, new ShipModel { id = "battleship", type = ShipType.Battleship, length = 4 } },
-            { ShipType.Submarine, new ShipModel { id = "submarine", type = ShipType.Submarine, length = 1 } },
-            { ShipType.Destroyer, new ShipModel { id = "destroyer", type = ShipType.Destroyer, length = 2 } },
-            { ShipType.Cruiser, new ShipModel { id = "cruiser", type = ShipType.Cruiser, length = 3 } }
+            { ShipType.Battleship, new ShipModel { id = "battleship", type = ShipType.Battleship, length = 4, movementPattern = ShipMovementPattern.CreateMovementPattern(ShipType.Battleship) } },
+            { ShipType.Submarine, new ShipModel { id = "submarine", type = ShipType.Submarine, length = 1, movementPattern = ShipMovementPattern.CreateMovementPattern(ShipType.Submarine) } },
+            { ShipType.Destroyer, new ShipModel { id = "destroyer", type = ShipType.Destroyer, length = 2, movementPattern = ShipMovementPattern.CreateMovementPattern(ShipType.Destroyer) } },
+            { ShipType.Cruiser, new ShipModel { id = "cruiser", type = ShipType.Cruiser, length = 3, movementPattern = ShipMovementPattern.CreateMovementPattern(ShipType.Cruiser) } }
         };
     }
     

--- a/Assets/_Scripts/Core/Ship/ShipMovementPattern.cs
+++ b/Assets/_Scripts/Core/Ship/ShipMovementPattern.cs
@@ -24,7 +24,15 @@ namespace Core.Ship
         public bool canMoveAfterRotating = false;
         public int maxMovementPoints = 1;
         public int movesRemaining = 1;
+        public bool hasAlreadyMoved = false;
         public bool hasAlreadyRotated = false;
+
+        public bool canMove => !hasAlreadyMoved && (!hasAlreadyRotated || canMoveAfterRotating);
+
+        // The initial design used to be that if it rotated, it would subtract 1 from the movesRemaining
+        //      and it could only rotate if it hadn't moved it's full maxMovementPoints, but I don't see that in the GDD anymore
+        //public bool canRotate => !hasAlreadyRotated && (!hasAlreadyMoved || canMoveAfterRotating && movesRemaining > 0);
+        public bool canRotate => !hasAlreadyRotated && (!hasAlreadyMoved || canMoveAfterRotating);
 
 
         public static ShipMovementPattern CreateMovementPattern(ShipType type)
@@ -43,6 +51,7 @@ namespace Core.Ship
         {
             movesRemaining = maxMovementPoints;
             hasAlreadyRotated = false;
+            hasAlreadyMoved = false;
         }
 
         // AI Movement Decision Rules:
@@ -88,7 +97,7 @@ namespace Core.Ship
             Orientation newOrientation = ship.orientation;
             List<Orientation> validOrientations = new List<Orientation>();     // valid Orientations that the ship can fit
 
-            if (ship.isDestroyed)   // destroyed ships can't rotate
+            if (!ship.canRotate)   // destroyed ships can't rotate
                 return false;
 
             // remove the current ship location so it doesn't block possible locations
@@ -118,7 +127,9 @@ namespace Core.Ship
             {
                 newOrientation = validOrientations[rnd.Next(validOrientations.Count)];
                 hasAlreadyRotated = true;
-                movesRemaining--;
+
+                // The initial design used to be that if it rotated, it would subtract 1 from the movesRemaining but I don't see that in the GDD anymore
+                //movesRemaining--;
             }
 
             // place the ship
@@ -135,6 +146,9 @@ namespace Core.Ship
             bool hasBeenSuccessfullyPlaced = true;
             GridPos originalPosition = ship.root;
             GridPos newPosition = ship.root;
+
+            if (!ship.canMove)   // destroyed ships can't rotate
+                return false;
 
             // remove the current ship location so it doesn't block possible locations
             board.Model.ResetShipCells(ship);
@@ -173,7 +187,7 @@ namespace Core.Ship
         public override List<GridPos> GetAllPossibleMovePositions(BoardView board, ShipModel ship)
         {
             List<GridPos> locations = new();
-            if (ship.isDestroyed)   // destroyed ships can't move
+            if (!ship.canMove)    // destroyed ships can't move. and can't move again if already moved or rotated
                 return locations;
 
             GridPos originalPosition = ship.root;
@@ -204,7 +218,7 @@ namespace Core.Ship
         public override List<GridPos> GetAllPossibleMovePositions(BoardView board, ShipModel ship)
         {
             List<GridPos> locations = new();
-            if (ship.isDestroyed)   // destroyed ships can't move
+            if (!ship.canMove)   // destroyed ships can't move. and can't move again if already moved or rotated
                 return locations;
 
             GridPos originalPosition = ship.root;
@@ -245,7 +259,7 @@ namespace Core.Ship
         public override List<GridPos> GetAllPossibleMovePositions(BoardView board, ShipModel ship)
         {
             List<GridPos> locations = new();
-            if (ship.isDestroyed)   // destroyed ships can't move
+            if (!ship.canMove)    // destroyed ships can't move.
                 return locations;
 
             GridPos originalPosition = ship.root;     
@@ -319,7 +333,7 @@ namespace Core.Ship
         public override List<GridPos> GetAllPossibleMovePositions(BoardView board, ShipModel ship)
         {
             List<GridPos> locations = new();
-            if (ship.isDestroyed)   // destroyed ships can't move
+            if (!ship.canMove)    // destroyed ships can't move.
                 return locations;
 
             GridPos originalPosition = ship.root;

--- a/Assets/_Scripts/Core/Ship/ShipView.cs
+++ b/Assets/_Scripts/Core/Ship/ShipView.cs
@@ -319,6 +319,10 @@ namespace Core.Ship
             if (ValidateRotation(targetOrientation))
             {
                 UpdatePosition(shipModel.root, targetOrientation);
+
+                if (GameManager.instance.phaseState != GameManager.PHASE_STATE.PLAYER_PLACING_SHIPS)
+                    shipModel.movementPattern.hasAlreadyRotated = true;
+
                 return true;
             }
 
@@ -332,6 +336,10 @@ namespace Core.Ship
             if (ValidateRotation(targetOrientation))
             {
                 UpdatePosition(shipModel.root, targetOrientation);
+
+                if (GameManager.instance.phaseState != GameManager.PHASE_STATE.PLAYER_PLACING_SHIPS)
+                    shipModel.movementPattern.hasAlreadyRotated = true;
+
                 return true;
             }
             return false;
@@ -339,6 +347,9 @@ namespace Core.Ship
 
         private bool ValidateRotation(Orientation orientation)
         {
+            if (!shipModel.canRotate)
+                return false;
+
             var shipModelCopy = shipModel.Copy();
             shipModelCopy.orientation = orientation;
             return _originBoardView.Model.ValidateShipPlacement(shipModelCopy, new List<GridPos> { shipModelCopy.root });

--- a/Assets/_Scripts/GameManager.cs
+++ b/Assets/_Scripts/GameManager.cs
@@ -20,6 +20,8 @@ public class GameManager : MonoBehaviour
     public bool winConditionMet;
     public bool loseConditionMet;
     public Button nextPhaseBtn;
+    public Button rotateLeftButton;
+    public Button rotateRightButton;
 
 
     public GameObject GameOverPanel;
@@ -310,6 +312,7 @@ public class GameManager : MonoBehaviour
     private void PlayerMoves()
     {
         boardController.playerView.SaveShipLocations();     // saves all of the ships locations/rotations in case reset button is pressed
+        boardController.playerView.BeginMovementPhase();    // resets their ability to move and rotate
 
         Debug.Log("Waiting for Player to move...");
 


### PR DESCRIPTION
 - added canMove and canRotate to ShipMovementPattern and ShipModel and check for it in all ships' versions of GetAllPossibleMovePositions()
 - set the ShipMovementPattern's hasAlreadyMoved and hasAlreadyRotated to true
 - Reset button and new turn resets the ShipMovementPattern's hasAlreadyMoved and hasAlreadyRotated
 - Set the interactability of RotateLeft and RotateRight buttons based on the selected ship's canRotate value

requirements: https://docs.google.com/document/d/1IljDwNI5Vi58-gpSA9zRxogaG-URZlzSrZ0giU8u50w/edit?tab=t.0#heading=h.j8xz4z7uvy6y